### PR TITLE
Updating k8s deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,12 +10,8 @@ jobs:
 
   call-test-maven-jar:
     name: Run Automated Tests - Maven JAR
-    uses: eclipse-pass/playground/.github/workflows/maven-jar-test.yml@56509e3819434a8bf283580f5bbc0c3ea65d77c0
+    uses: eclipse-pass/playground/.github/workflows/maven-jar-test.yml@main
 
   call-test-maven-service:
     name: Run Automated Tests - Maven service
-    uses: eclipse-pass/playground/.github/workflows/maven-service-test.yml@56509e3819434a8bf283580f5bbc0c3ea65d77c0
-
-  temp-call-html-app-publish:
-    name: TEMP - run html-app publish step for testing
-    uses: eclipse-pass/playground/.github/workflows/html-app-publish.yml@56509e3819434a8bf283580f5bbc0c3ea65d77c0
+    uses: eclipse-pass/playground/.github/workflows/maven-service-test.yml@main

--- a/.github/workflows/update-k8s-manifest.py
+++ b/.github/workflows/update-k8s-manifest.py
@@ -7,14 +7,6 @@ def print_usage():
     print("This script edits a Kubernetes manifest file to include a new version number on a container image.")
     print("\n  update-k8s-manifest.py <manifest file path> <new container image version>")
 
-def get_yaml_value(line):
-    keyIndex = line.find(":")
-    return line[keyIndex+1:].strip()
-
-def replace_image_version(image, newVersion):
-    versionIndex = image.rfind(":")
-    return image[:versionIndex+1] + newVersion
-
 if len(sys.argv) != 3:
     print("\nERROR! Incorrect number of arguments provided (" + str(len(sys.argv)) + "), expected 2\n")
     print_usage()
@@ -36,9 +28,7 @@ for line in lines:
         if line.lstrip().startswith("image:"):
             imageIndex = line.find("image:")
             whitespace = line[:imageIndex]
-            image = get_yaml_value(line)
-            updatedImage = replace_image_version(image, sys.argv[2])
-            outputFile += whitespace + "image: " + updatedImage + os.linesep
+            outputFile += whitespace + "image: " + sys.argv[2] + os.linesep
             updateDone = True
         else:
             outputFile += line


### PR DESCRIPTION
It turns out that if you have a git commit + push in a GH Actions workflow, it merges the PR that includes  that change. This is removing the temporary inclusion of k8s deploy in the CI step and simplifying the manifest update to replace the entire image name.